### PR TITLE
[refactor] Fixed session handling & credential checks.

### DIFF
--- a/cmd/newRoutes.go
+++ b/cmd/newRoutes.go
@@ -1,19 +1,18 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 	"net/http"
 
-	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
-	"github.com/gorilla/sessions"
 )
 
 func CreateWebRouter() *mux.Router {
 	router := mux.NewRouter()
 	// Public Routes
 	//router.HandleFunc("/scores", Score)
-	router.HandleFunc("/login", Login)
+	router.HandleFunc("/login", ShowLogin).Methods("GET")
+	router.HandleFunc("/login", SubmitLogin).Methods("POST")
 	// API Routes
 	router.HandleFunc("/flags", GetFlags).Methods("GET")
 	router.HandleFunc("/flags/verify", CheckFlag).Methods("POST")
@@ -47,28 +46,55 @@ func Score(w http.ResponseWriter, r *http.Request) {
 }
 */
 
-func Login(w http.ResponseWriter, r *http.Request) {
-	session := context.Get(r, "session").(*sessions.Session)
-	switch {
-	case r.Method == "GET":
-		http.Redirect(w, r, "/login.html", 302)
-	case r.Method == "POST":
-		succ, err := CheckCreds(r)
-		if err != nil {
-			fmt.Println(err)
-		}
-		if succ {
-			session.Save(r, w)
-			http.Redirect(w, r, "/team/teamPage", 302)
-		} else {
-			http.Redirect(w, r, "/login.html", 302)
-		}
+func ShowLogin(w http.ResponseWriter, r *http.Request) {
+	// TODO(pereztr5): Render a template instead of re-directing to a static page
+	http.Redirect(w, r, "/login.html", 302)
+}
+
+func SubmitLogin(w http.ResponseWriter, r *http.Request) {
+	session, err := Store.Get(r, "cyboard")
+	if err != nil {
+		http.Error(w, http.StatusText(400), 400)
+		return
 	}
+
+	succ, err := CheckCreds(r)
+	if err != nil {
+		// Print a more verbose error message for debugging purposes
+		log.Printf("CheckCreds failed: %v", err)
+		http.Error(w, http.StatusText(403), 403)
+		return
+	}
+
+	if succ {
+		err = session.Save(r, w)
+		if err != nil {
+			http.Error(w, http.StatusText(500), 500)
+			return
+		}
+
+		http.Redirect(w, r, "/team/teamPage", 302)
+		return
+	}
+
+	http.Redirect(w, r, "/login.html", 302)
 }
 
 func Logout(w http.ResponseWriter, r *http.Request) {
-	session := context.Get(r, "session").(*sessions.Session)
+	session, err := Store.Get(r, "cyboard")
+	if err != nil {
+		http.Error(w, http.StatusText(400), 400)
+		return
+	}
+
 	delete(session.Values, "id")
+	// Make sure we save the session after deleting the ID.
+	err = session.Save(r, w)
+	if err != nil {
+		http.Error(w, http.StatusText(500), 500)
+		return
+	}
+
 	http.Redirect(w, r, "/login.html", 302)
 }
 


### PR DESCRIPTION
- Call store.Get instead of checking the context redundantly.
- Split the login handlers into separate GET and POST related functions.
- Correctly call 'return' after http.Redirect where necessary.
