### PR TITLE
Formalize configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
-vendor
-event
-.*
-!/.gitignore
+# Binaries
+cyboard
+*.exe
+
+# Dependency management
+.glide/
+vendor/
+
+# Default cyboard dirs
+log/
+scripts/
+
+# Secrets
 *.pem
 *.key
-cyboard
-scripts/*
-captured_flags.log
-log/*

--- a/checks.toml
+++ b/checks.toml
@@ -1,5 +1,6 @@
+[event]
 checks_dir = "scripts"
-event_end_time = "Fri Apr 22 19:24:29 EDT 2016"
+event_end_time = 2017-11-04T19:30:00-05:00
 intervals = "5s"
 timeout = "4s"
 on_break = false
@@ -10,23 +11,30 @@ level = "info"
 # use stdout instead of a file
 stdout = false
 
-[checks]
-    [checks.1]
-    check_name = "ping"
-    filename = "check_ping"
-    points = [ 1, 0, 0 ]
-    args = "-H IP -w 200,50% -c 500,100% -t 5 -p 1"
+[database]
+mongodb_uri = "mongodb://127.0.0.1"
+dbname = "scorengine"
 
-    [checks.2]
-    check_name = "web"
-    filename = "check_http"
-    points = [ 10, 0, 0 ]
-    args = "-I IP -t 5"
-    disable = false
+# The double-brackets make an array of structs, zero-indexed.
+# This is just a weird config file quirk, copy it for each script added and move on.
+[[checks]]
+# check.1
+check_name = "ping"
+filename = "check_ping"
+points = [ 1, 0, 0 ]
+args = "-H IP -w 200,50% -c 500,100% -t 5 -p 1"
 
-    [checks.3]
-    check_name = "IP"
-    filename = "test.sh"
-    points = [ 10, 0, 0 ]
-    args = "IP"
-    disable = true
+[[checks]]
+# check.2
+check_name = "web"
+filename = "check_http"
+points = [ 10, 0, 0 ]
+args = "-I IP -t 5"
+disable = false
+
+[[checks]]
+check_name = "IP"
+filename = "test.sh"
+points = [ 10, 0, 0 ]
+args = "IP"
+disable = true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,9 @@ func initConfig(v *viper.Viper, configName string) {
 		os.Exit(1)
 	}
 
-	// Bind global flags to this specific config's values
+	// Bind global flags & env vars to this specific config's values
+	v.BindEnv("database.mongodb_uri", "MONGODB_URI")
+
 	flags := RootCmd.PersistentFlags()
 	v.BindPFlag("database.mongodb_uri", flags.Lookup("mongodb-uri"))
 	v.BindPFlag("log.stdout", flags.Lookup("stdout"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -11,44 +12,77 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "cyboard",
 	Short: "Scoring Engine",
-	Long:  `This will start the Scoring Engine`,
+	Long:  `Root of the Scoring Engine application (see Available Commands)`,
 	Run:   RootRun,
 }
-
-var CfgFile string
+var (
+	dumpConfig    bool
+	rootCmdConfig = viper.New()
+)
 
 func init() {
-	cobra.OnInitialize(initConfig)
-	RootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "config file (default is $HOME/.cyboard/config.toml)")
-	RootCmd.AddCommand(ServerCmd)
-	RootCmd.AddCommand(CheckCmd)
+	// This declares top level flags, shared by all commands
+	flags := RootCmd.PersistentFlags()
+	flags.BoolVar(&dumpConfig, "dump-config", false,
+		"Prints the parsed server / check config (for debugging purposes)")
+	flags.String("mongodb-uri", "mongodb://127.0.0.1",
+		"Address of MongoDB instance to use. Also configured with the environment var: `MONGODB_URI`")
+	flags.BoolP("stdout", "s", false, "Log to standard out")
+
+	RootCmd.AddCommand(ServerCmd, CheckCmd)
 }
 
-func initConfig() {
-	if CfgFile != "" {
-		viper.SetConfigFile(CfgFile)
+// initConfig loads the config file from disk, searching in order:
+// `-c|--config` option path, configName in the cwd, or configName in `$HOME/.cyboard/`
+//
+// This function is used for both the CTF & Service checker (but not the RootCmd)
+func initConfig(v *viper.Viper, configName string) {
+	path := v.GetString("configPath")
+	if path != "" {
+		v.SetConfigFile(path)
+	} else {
+		v.SetConfigName(configName)
+		v.AddConfigPath(".")
+		v.AddConfigPath("$HOME/.cyboard/")
 	}
-	viper.SetConfigName("config")
-	viper.AddConfigPath("$HOME/.cyboard/")
-	viper.AddConfigPath(".")
-	err := viper.ReadInConfig()
-	if err != nil {
+
+	if err := v.ReadInConfig(); err != nil {
 		fmt.Println("Fatal error config file:", err)
+		os.Exit(1)
+	}
+
+	// Bind global flags to this specific config's values
+	flags := RootCmd.PersistentFlags()
+	v.BindPFlag("database.mongodb_uri", flags.Lookup("mongodb-uri"))
+	v.BindPFlag("log.stdout", flags.Lookup("stdout"))
+}
+
+// checkForDebugDump will dump the parsed config file and then exit the app
+func checkForDebugDump(v *viper.Viper) {
+	if dumpConfig {
+		// v.ConfigFileUsed is empty when viper is given an explicit config path with `v.SetConfigFile()`
+		fileUsed := v.ConfigFileUsed()
+		if fileUsed != "" {
+			fmt.Println(fileUsed)
+		}
+
+		keys := v.AllKeys()
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("  %s: %v\n", k, v.Get(k))
+		}
+		os.Exit(0)
+	}
+}
+
+// mustUnmarshal unmarshals a viper config into the cfg struct, or errors the app and exits
+func mustUnmarshal(v *viper.Viper, cfg interface{}) {
+	if err := v.Unmarshal(cfg); err != nil {
+		fmt.Println("Unmarshal of config failed:", err)
 		os.Exit(1)
 	}
 }
 
 func RootRun(cmd *cobra.Command, args []string) {
-	// For debugging purposes
-	fmt.Println(viper.GetString("appname"))
-	fmt.Println(viper.GetString("server.ip"))
-	fmt.Println(viper.GetString("server.http_port"))
-	fmt.Println(viper.GetString("server.https_port"))
-	fmt.Println(viper.GetString("server.cert"))
-	fmt.Println(viper.GetString("server.key"))
-	fmt.Println(viper.GetString("database.mongodb_uri"))
-	err := cmd.Help()
-	if err != nil {
-		fmt.Println(err)
-	}
+	cmd.Help()
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -6,25 +6,33 @@ import (
 	"github.com/spf13/viper"
 )
 
-var ServerCmd = &cobra.Command{
-	Use:   "server",
-	Short: "Web server for static pages and api",
-	Long:  `This will run the web server`,
-	Run:   serverRun,
-}
+var (
+	ServerCmd = &cobra.Command{
+		Use:   "server",
+		Short: "Web server for static pages and api",
+		Long:  `This will run the web server`,
+		Run:   serverRun,
+	}
+	serverConfig = viper.New()
+)
 
 func init() {
-	ServerCmd.Flags().Int("http_port", 8080, "HTTP Port for cyboard used for redirect")
-	ServerCmd.Flags().Int("https_port", 1443, "HTTPS Port for cyboard")
-	ServerCmd.Flags().Bool("stdout", false, "Log to standard out")
-	ServerCmd.PersistentFlags().String("mongodb_uri", "mongodb://127.0.0.1", "Address of MongoDB in use")
-	viper.BindPFlag("log.stdout", ServerCmd.Flags().Lookup("stdout"))
-	viper.BindPFlag("server.http_port", ServerCmd.Flags().Lookup("http_port"))
-	viper.BindPFlag("server.https_port", ServerCmd.Flags().Lookup("https_port"))
-	viper.BindPFlag("database.mongodb_uri", ServerCmd.PersistentFlags().Lookup("mongodb_uri"))
+	flags := ServerCmd.Flags()
+	flags.StringP("config", "c", "", "config file (default is $HOME/.cyboard/config.toml)")
+	flags.Int("http-port", 8080, "HTTP Port for cyboard used for redirect")
+	flags.Int("https-port", 8081, "HTTPS Port for cyboard")
+
+	serverConfig.BindPFlag("configPath", flags.Lookup("config"))
+	serverConfig.BindPFlag("server.http_port", flags.Lookup("http-port"))
+	serverConfig.BindPFlag("server.https_port", flags.Lookup("https-port"))
 }
 
 func serverRun(cmd *cobra.Command, args []string) {
-	server.SetupServerCfg(viper.GetViper())
-	server.Run()
+	// The server's config is `config.toml` by default
+	initConfig(serverConfig, "config")
+	checkForDebugDump(serverConfig)
+
+	c := &server.Configuration{}
+	mustUnmarshal(serverConfig, c)
+	server.Run(c)
 }

--- a/config.toml
+++ b/config.toml
@@ -4,8 +4,8 @@ appname = "CNY Hackathon"
 ip = "127.0.0.1"
 http_port = "8080"
 https_port = "8081"
-cert = "certs/cert.pem"
-key = "certs/key.pem"
+# cert = "certs/cert.pem"
+# key = "certs/key.pem"
 
 # Most CTF challenges do not show their name to any blue teams.
 # Challenges in the following group will be displayed on a

--- a/server/mongodb.go
+++ b/server/mongodb.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/mgo.v2"
@@ -18,13 +17,11 @@ var (
 func DBSession() *mgo.Session {
 	if mongodbSession == nil {
 		Logger.Println("Making new MongoDB Session")
-		uri := os.Getenv("MONGODB_URI")
+		uri := dbSettings.URI
 		if uri == "" {
-			uri = dbSettings.URI
-			if uri == "" {
-				Logger.Fatalln("No connection uri for MongoDB provided")
-			}
+			Logger.Fatalln("No connection uri for MongoDB provided")
 		}
+
 		var err error
 		mongodbSession, err = mgo.Dial(uri)
 		if mongodbSession == nil || err != nil {

--- a/server/mongodb.go
+++ b/server/mongodb.go
@@ -4,20 +4,23 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/viper"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
-var mongodbSession *mgo.Session
+var (
+	mongodbSession    *mgo.Session
+	dbSettings        *DBSettings
+	specialChallenges []string
+)
 
 func DBSession() *mgo.Session {
 	if mongodbSession == nil {
 		Logger.Println("Making new MongoDB Session")
 		uri := os.Getenv("MONGODB_URI")
 		if uri == "" {
-			uri = viper.GetString("database.mongodb_uri")
+			uri = dbSettings.URI
 			if uri == "" {
 				Logger.Fatalln("No connection uri for MongoDB provided")
 			}
@@ -25,7 +28,7 @@ func DBSession() *mgo.Session {
 		var err error
 		mongodbSession, err = mgo.Dial(uri)
 		if mongodbSession == nil || err != nil {
-			Logger.Fatalf("Can't connect to MongoDB: ", err)
+			Logger.Fatalln("Can't connect to MongoDB: ", err)
 		}
 		mongodbSession.SetSafe(&mgo.Safe{})
 		Logger.Println("Connected to mongodb:", mongodbSession.LiveServers())
@@ -34,7 +37,7 @@ func DBSession() *mgo.Session {
 }
 
 func DB() *mgo.Database {
-	return DBSession().DB(viper.GetString("database.dbname"))
+	return DBSession().DB(dbSettings.DBName)
 }
 
 func Teams() *mgo.Collection {
@@ -98,8 +101,21 @@ func GetSessionAndCollection(collectionName string) (sessionCopy *mgo.Session, c
 		Logger.Println("No sessions available making new one")
 		sessionCopy = DBSession().Copy()
 	}
-	collection = sessionCopy.DB(viper.GetString("database.dbname")).C(collectionName)
+	collection = sessionCopy.DB(dbSettings.DBName).C(collectionName)
 	return
+}
+
+// SetupMongo copies settings into app-wide vars used for connecting & interacting with MongoDB
+func SetupMongo(settings *DBSettings, special []string) {
+	// If the DBName is empty, the mongo driver will fallback to `test`, but we'd rather fail fast.
+	if settings.DBName == "" {
+		Logger.Fatal(`DB name is empty: database.dbname=""`)
+	}
+
+	s := *settings
+	dbSettings = &s
+
+	specialChallenges = special
 }
 
 func EnsureAdmin() {

--- a/server/queries.go
+++ b/server/queries.go
@@ -252,7 +252,7 @@ func DataGetTeamScore(teamname string) int {
 	})
 	err := pipe.One(&points)
 	if err != nil {
-		Logger.Error("Error getting team points: ", err)
+		Logger.Errorf("Error getting `%s` points: %v", teamname, err)
 	} else {
 		p = points["points"].(int)
 	}


### PR DESCRIPTION
```
Improve app configuration

    Configuration is now kept in well-defined structs, which
    are easier to track and more type safe. Adding new config
    options should be easier, and there is less reliance on
    almighty global values and opaque *viper.Viper configs.

    This is preliminary work for untangling this app, and getting tests!

    - Fixed passing config location via the command line
    - Reworked `cmd` package, reusing code
    - Removed global variables where able
    - Improved error log messages
    - Toggled on compression of log files, on rotation

Allow plain HTTP if certs are not configured

    For speeding up development & initial site stand up.
```

This all began because I was testing things and and discovered that the `--config` flag for overriding the config file location was busted. One thing led to another, and now there's this few hundred line PR. All part of the cycle of coming back every few months and trying to remember how everything works!