### PR TITLE
Performance tune-up

### DIFF
--- a/server/mongodb.go
+++ b/server/mongodb.go
@@ -75,10 +75,8 @@ func CreateIndexes() {
 			{Key: []string{"flag", "name"}}, // DataCheckFlag
 		},
 		"results": {
-			{Key: []string{"type", "group"}},       // DataGetResultByService
-			{Key: []string{"teamname", "details"}}, // HasFlag
-			{Key: []string{"teamname", "type"}},    // DataGetTeamChallenges
-			{Key: []string{"group"}},               // DataGetSubmissionsPerFlag & DataGetEachTeamsCapturedFlags
+			{Key: []string{"type", "group"}}, // DataGetResultByService, DataGetSubmissionsPerFlag, DataGetEachTeamsCapturedFlags, HasFlag, DataGetTeamChallenges (partial)
+			{Key: []string{"points"}}, // DataGetAllScore & DataGetAllScoreSplitByType
 		},
 	}
 

--- a/server/queries.go
+++ b/server/queries.go
@@ -471,7 +471,9 @@ func DataGetLastServiceResult() time.Time {
 	}).One(&id)
 	var latest time.Time
 	if err != nil {
-		Logger.Error("Error getting last Service result: ", err)
+		if err != mgo.ErrNotFound {
+			Logger.Error("Error getting last Service result: ", err)
+		}
 	} else {
 		latest = id["last"].(bson.ObjectId).Time()
 	}
@@ -491,7 +493,9 @@ func DataGetLastResult() time.Time {
 	}).One(&id)
 	var latest time.Time
 	if err != nil {
-		Logger.Error("Error getting last document: ", err)
+		if err != mgo.ErrNotFound {
+			Logger.Error("Error getting last document: ", err)
+		}
 	} else {
 		latest = id["last"].(bson.ObjectId).Time()
 	}

--- a/server/queries.go
+++ b/server/queries.go
@@ -296,7 +296,7 @@ func DataGetAllScore() []ScoreResult {
 
 	teams := DataGetTeams()
 	err := collection.Pipe([]bson.M{
-		{"$match": bson.M{"points": bson.M{"$gt": 0}}},
+		{"$match": bson.M{"points": bson.M{"$ne": 0}}},
 		{"$group": bson.M{"_id": bson.M{"tname": "$teamname", "tnum": "$teamnumber"}, "points": bson.M{"$sum": "$points"}}},
 		{"$project": bson.M{"_id": 0, "teamnumber": "$_id.tnum", "teamname": "$_id.tname", "points": 1}},
 		{"$sort": bson.M{"teamnumber": 1}},
@@ -326,7 +326,7 @@ func DataGetAllScoreSplitByType() []ScoreResult {
 	tmScore := make([]ScoreResult, 0, len(teams)*2)
 
 	err := collection.Pipe([]bson.M{
-		{"$match": bson.M{"points": bson.M{"$gt": 0}}},
+		{"$match": bson.M{"points": bson.M{"$ne": 0}}},
 		{"$group": bson.M{"_id": bson.M{"tname": "$teamname", "tnum": "$teamnumber", "type": "$type"}, "points": bson.M{"$sum": "$points"}}},
 		{"$project": bson.M{"_id": 0, "teamnumber": "$_id.tnum", "teamname": "$_id.tname", "type": "$_id.type", "points": 1}},
 		{"$sort": bson.M{"teamnumber": 1, "type": 1}},

--- a/server/queries.go
+++ b/server/queries.go
@@ -516,6 +516,21 @@ func DataAddResult(result Result, test bool) error {
 	return nil
 }
 
+func DataAddResults(results []Result, test bool) error {
+	docs := make([]interface{}, len(results))
+	for i, result := range results {
+		docs[i] = result
+	}
+
+	collName := "results"
+	if test {
+		collName = "testResults"
+	}
+	session, collection := GetSessionAndCollection(collName)
+	defer session.Close()
+	return collection.Insert(docs...)
+}
+
 func DataAddTeams(teams []Team) error {
 	session, teamC := GetSessionAndCollection("teams")
 	defer session.Close()

--- a/server/queries.go
+++ b/server/queries.go
@@ -28,12 +28,12 @@ type Challenge struct {
 
 type Result struct {
 	Id         bson.ObjectId `json:"id,omitempty" bson:"_id,omitempty"`
-	Type       string        `json:"type" bson:"type"`
+	Type       string        `json:"type,omitempty" bson:"type"`
 	Timestamp  time.Time     `json:"timestamp" bson:"timestamp"`
-	Group      string        `json:"group" bson:"group"`
+	Group      string        `json:"group,omitempty" bson:"group"`
 	Teamname   string        `json:"teamname" bson:"teamname"`
 	Teamnumber int           `json:"teamnumber" bson:"teamnumber"`
-	Details    string        `json:"details" bson:"details"`
+	Details    string        `json:"details,omitempty" bson:"details"`
 	Points     int           `json:"points" bson:"points"`
 }
 
@@ -386,23 +386,12 @@ func DataGetServiceList() []string {
 	session, collection := GetSessionAndCollection("results")
 	defer session.Close()
 	var list []string
-	res := bson.M{}
 
-	pipe := collection.Pipe([]bson.M{
-		{"$match": bson.M{"type": "Service"}},
-		{"$group": bson.M{"_id": "$group"}},
-		{"$project": bson.M{"_id": 0, "group": "$_id"}},
-		{"$sort": bson.M{"group": 1}},
-	})
-	iter := pipe.Iter()
-	for iter.Next(&res) {
-		list = append(list, res["group"].(string))
-	}
-	if err := iter.Close(); err != nil {
+	err := collection.Find(bson.M{"type": "Service"}).Distinct("group", &list)
+	if err != nil {
 		Logger.Error("Error getting service list: ", err)
 	}
 	return list
-
 }
 
 // TODO: Combine queries since this has repeating code

--- a/server/queries_test.go
+++ b/server/queries_test.go
@@ -16,8 +16,6 @@ var TestTeams = []Team{
 	{bson.NewObjectId(), "blueteam", 2, "team2", "127.0.0.2", genPass("pass2"), ""},
 }
 
-var ScoreCategories = []string{"CTF", "Service"}
-
 func init() {
 	SetupScoringLoggers(&LogSettings{Level: "warn", Stdout: true})
 	ensureTestDB()

--- a/server/routes.go
+++ b/server/routes.go
@@ -211,7 +211,7 @@ func GetServices(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getChallenges() map[string]int {
+func getChallenges() []ChallengeCount {
 	totals, err := DataGetTotalChallenges()
 	if err != nil {
 		Logger.Error("Could not get challenges: ", err)
@@ -219,7 +219,7 @@ func getChallenges() map[string]int {
 	return totals
 }
 
-func getTeamChallenges(teamname string) map[string]int {
+func getTeamChallenges(teamname string) []ChallengeCount {
 	acquired, err := DataGetTeamChallenges(teamname)
 	if err != nil {
 		Logger.Error("Could not get team challenges: ", err)

--- a/server/routes.go
+++ b/server/routes.go
@@ -30,6 +30,7 @@ func ensureAppTemplates() {
 		"teamChallenges":     getTeamChallenges,
 		"teamScore":          getTeamScore,
 		"allTeamScores":      getAllTeamScores,
+		"allBlueTeams":       DataGetTeams,
 		"getOwnedChalGroups": getChallengesOwnerOf,
 		"getStatus":          DataGetResultByService,
 		"serviceList":        DataGetServiceList,
@@ -65,6 +66,7 @@ func CreateWebRouter() *mux.Router {
 	router.HandleFunc("/team/scores/split", GetScoresSplit).Methods("GET")
 	router.HandleFunc("/team/scores/live", ServeScoresWs).Methods("GET")
 	router.HandleFunc("/team/services/live", ServeServicesWs).Methods("GET")
+	router.HandleFunc("/services", GetServices).Methods("GET")
 	return router
 }
 
@@ -197,6 +199,14 @@ func GetScoresSplit(w http.ResponseWriter, r *http.Request) {
 	scores := DataGetAllScoreSplitByType()
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	if err := json.NewEncoder(w).Encode(scores); err != nil {
+		Logger.Error("Error encoding json: ", err)
+	}
+}
+
+func GetServices(w http.ResponseWriter, r *http.Request) {
+	services := DataGetServiceList()
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	if err := json.NewEncoder(w).Encode(services); err != nil {
 		Logger.Error("Error encoding json: ", err)
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -51,7 +51,7 @@ func ensureAppTemplates() {
 	}
 }
 
-func CreateWebRouter() *mux.Router {
+func CreateWebRouter(teamScoreUpdater, servicesUpdater *broadcastHub) *mux.Router {
 	router := mux.NewRouter()
 	// Public Routes
 	router.HandleFunc("/", ShowHome).Methods("GET")
@@ -64,8 +64,8 @@ func CreateWebRouter() *mux.Router {
 	// TODO: Make this the name of AIS challenge
 	router.HandleFunc("/team/scores", GetScores).Methods("GET")
 	router.HandleFunc("/team/scores/split", GetScoresSplit).Methods("GET")
-	router.HandleFunc("/team/scores/live", ServeScoresWs).Methods("GET")
-	router.HandleFunc("/team/services/live", ServeServicesWs).Methods("GET")
+	router.HandleFunc("/team/scores/live", teamScoreUpdater.ServeWs()).Methods("GET")
+	router.HandleFunc("/team/services/live", servicesUpdater.ServeWs()).Methods("GET")
 	router.HandleFunc("/services", GetServices).Methods("GET")
 	return router
 }

--- a/server/run.go
+++ b/server/run.go
@@ -49,7 +49,10 @@ func Run(cfg *Configuration) {
 	// On first run, prompt to set up an admin user
 	EnsureAdmin()
 
-	webRouter := CreateWebRouter()
+	teamScoreUpdater, servicesUpdater := TeamScoreWsServer(), ServiceStatusWsServer()
+	defer teamScoreUpdater.Stop()
+	defer servicesUpdater.Stop()
+	webRouter := CreateWebRouter(teamScoreUpdater, servicesUpdater)
 	teamRouter := CreateTeamRouter()
 	adminRouter := CreateAdminRouter()
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -26,7 +26,7 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
-func getTeamScoreIfModified(lastMod time.Time) ([]Result, time.Time, error) {
+func getTeamScoreIfModified(lastMod time.Time) ([]ScoreResult, time.Time, error) {
 	mod := DataGetLastResult()
 	if !mod.After(lastMod) {
 		return nil, lastMod, nil
@@ -73,7 +73,7 @@ func writer(ws *websocket.Conn, lastMod time.Time, which string) {
 	for {
 		select {
 		case <-updateTicker.C:
-			var r []Result
+			var r []ScoreResult
 			var t []ServiceStatus
 			var err error
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -1,134 +1,218 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
 )
 
 const (
-	// Time allowed to write the file to the client.
+	// Poll the db for updates, using broadcastHub.timeCheck() at the end of each period.
+	updatePeriod = 5 * time.Second
+
+	// Deadline for write operations to any client. If missed, the client is dropped.
 	writeWait = 10 * time.Second
 
-	// Time allowed to read the next pong message from the client.
-	pongWait = 60 * time.Second
-
-	// Send pings to client with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
-
-	// Poll file for changes with this period.
-	updatePeriod = 2 * time.Second
+	// Send pings to clients with this period. If missed, the client is dropped.
+	pingPeriod = 10 * time.Second
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
+// broadcastHub allows a form of pub/sub messaging, in which many subscribers
+// listen to data from a single publisher. Whenever new data is received, the
+// hub will prepare the data once, and then send it to each client.
+type broadcastHub struct {
+	logID   string
+	closeCh chan struct{}
+	conns   map[*websocket.Conn]chan *websocket.PreparedMessage
+
+	// Lock for the conns map. Could use sync.Map from Go v1.9, but supporting v1.8
+	// is nice for distros such as CentOS and Ubuntu.
+	*sync.RWMutex
+
+	timeCheck  func() (time.Time, error)
+	getPayload func() (interface{}, error)
 }
 
-func getTeamScoreIfModified(lastMod time.Time) ([]ScoreResult, time.Time, error) {
-	mod := DataGetLastResult()
-	if !mod.After(lastMod) {
-		return nil, lastMod, nil
-	}
-	r := DataGetAllScoreSplitByType()
-	return r, mod, nil
-}
+func NewBroadcastHub(logID string, timeCheck func() (time.Time, error), getPayload func() (interface{}, error)) *broadcastHub {
+	return &broadcastHub{
+		logID:      logID,
+		timeCheck:  timeCheck,
+		getPayload: getPayload,
 
-func getServiceIfModified(lastMod time.Time) ([]ServiceStatus, time.Time, error) {
-	mod := DataGetLastServiceResult()
-	if !mod.After(lastMod) {
-		return nil, lastMod, nil
-	}
-	r := DataGetServiceStatus()
-	/*
-		if len(r) == 0 {
-			return nil, mod, nil
-		}
-	*/
-	return r, mod, nil
-}
-
-func reader(ws *websocket.Conn) {
-	defer ws.Close()
-	ws.SetReadLimit(512)
-	ws.SetReadDeadline(time.Now().Add(pongWait))
-	ws.SetPongHandler(func(string) error { ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
-	for {
-		_, _, err := ws.ReadMessage()
-		if err != nil {
-			break
-		}
+		closeCh: make(chan struct{}),
+		conns:   make(map[*websocket.Conn]chan *websocket.PreparedMessage),
+		RWMutex: &sync.RWMutex{},
 	}
 }
 
-func writer(ws *websocket.Conn, lastMod time.Time, which string) {
-	pingTicker := time.NewTicker(pingPeriod)
+func (b *broadcastHub) logError(args ...interface{}) {
+	Logger.WithField("bcast", b.logID).Errorln(args...)
+}
+
+func (b *broadcastHub) addClient(ws *websocket.Conn) chan *websocket.PreparedMessage {
+	msgCh := make(chan *websocket.PreparedMessage, 1)
+	b.Lock()
+	b.conns[ws] = msgCh
+	b.Unlock()
+	return msgCh
+}
+
+func (b *broadcastHub) delClient(ws *websocket.Conn) {
+	ws.Close()
+	b.Lock()
+	delete(b.conns, ws)
+	b.Unlock()
+}
+
+// Stop sends a signal to the rest of the broadcastHub to shutdown.
+// It will then clean up on its own, after a short period.
+func (b *broadcastHub) Stop() {
+	close(b.closeCh)
+}
+
+// Start kicks off the broadcastHub's polling service, that connects
+// to the backend and waits for new data. When data shows up, the
+// broadcastHub will send it to each client. New clients are added in
+// the ServeWs method.
+func (b *broadcastHub) Start() {
 	updateTicker := time.NewTicker(updatePeriod)
-	defer func() {
-		pingTicker.Stop()
-		updateTicker.Stop()
-		ws.Close()
-	}()
+	defer updateTicker.Stop()
+
+	ts, _ := b.timeCheck()
 	for {
 		select {
 		case <-updateTicker.C:
-			var r []ScoreResult
-			var t []ServiceStatus
-			var err error
-
-			if which == "score" {
-				r, lastMod, err = getTeamScoreIfModified(lastMod)
-			} else if which == "service" {
-				t, lastMod, err = getServiceIfModified(lastMod)
-			}
+			newTs, err := b.timeCheck()
 			if err != nil {
-				Logger.Error("Could not get websocket team score: ", err)
+				b.logError("failed timeCheck: ", err)
+				continue
+			}
+			if ts.Equal(newTs) {
+				// no update
+				continue
 			}
 
-			if r != nil || t != nil {
-				ws.SetWriteDeadline(time.Now().Add(writeWait))
-				if which == "service" {
-					if err := ws.WriteJSON(t); err != nil {
-						return
-					}
-				} else {
-					if err := ws.WriteJSON(r); err != nil {
-						return
-					}
+			ts = newTs
+			payload, err := b.getPayload()
+			if err != nil {
+				b.logError("failed getPayload:", err)
+				continue
+			}
+
+			pm, err := prepPayload(payload)
+			if err != nil {
+				b.logError("failed prepPayload:", err)
+				continue
+			}
+
+			b.RLock()
+			for _, msgCh := range b.conns {
+				select {
+				case msgCh <- pm:
+				default: // Skip clients that can't take the message immediately.
 				}
 			}
-		case <-pingTicker.C:
-			ws.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := ws.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
-				return
+			b.RUnlock()
+		case <-b.closeCh:
+			// close all connections
+			for ws := range b.conns {
+				b.delClient(ws)
 			}
 		}
 	}
 }
 
-func ServeServicesWs(w http.ResponseWriter, r *http.Request) {
-	ws, err := upgrader.Upgrade(w, r, nil)
+func prepPayload(payload interface{}) (*websocket.PreparedMessage, error) {
+	data, err := json.Marshal(payload)
 	if err != nil {
-		if _, ok := err.(websocket.HandshakeError); !ok {
-			Logger.Error(err)
-		}
-		return
+		return nil, err
 	}
-
-	go writer(ws, DataGetLastServiceResult(), "service")
-	reader(ws)
+	return websocket.NewPreparedMessage(websocket.TextMessage, data)
 }
 
-func ServeScoresWs(w http.ResponseWriter, r *http.Request) {
-	ws, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		if _, ok := err.(websocket.HandshakeError); !ok {
-			Logger.Error(err)
-		}
-		return
+// ServeWs returns a http.HandlerFunc-ready function, which processes new
+// connections on a WebSocket client, and adds them as subscribers to the
+// broadcastHub.
+func (b *broadcastHub) ServeWs() func(http.ResponseWriter, *http.Request) {
+	// TODO: check that the write buffer size is a good fit (it's not)
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:    32,   // We don't care about reads
+		WriteBufferSize:   2560, // 2.5KB
+		EnableCompression: true,
 	}
 
-	go writer(ws, DataGetLastResult(), "score")
-	reader(ws)
+	return func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			if _, ok := err.(websocket.HandshakeError); !ok {
+				b.logError("handshake failed", err)
+			}
+			return
+		}
+
+		// Handle the new client
+		msgCh := b.addClient(ws)
+		go func(b *broadcastHub, ws *websocket.Conn, msgCh chan *websocket.PreparedMessage) {
+			defer b.delClient(ws)
+			pingTicker := time.NewTicker(pingPeriod)
+			defer pingTicker.Stop()
+
+			for {
+				select {
+				case msg, ok := <-msgCh:
+					if !ok {
+						return
+					}
+					ws.SetWriteDeadline(time.Now().Add(writeWait))
+					if err := ws.WritePreparedMessage(msg); err != nil {
+						b.logError(ws.RemoteAddr(), "write failed:", err)
+						return
+					}
+				case <-pingTicker.C:
+					ws.SetWriteDeadline(time.Now().Add(writeWait))
+					if err := ws.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
+						return
+					}
+				case <-b.closeCh:
+					return
+				}
+			}
+		}(b, ws, msgCh)
+
+		// Always discard messages sent from a client. On err (such as close), it will clean up.
+		go func(b *broadcastHub, ws *websocket.Conn) {
+			defer b.delClient(ws)
+			for {
+				if _, _, err := ws.NextReader(); err != nil {
+					ws.Close()
+					break
+				}
+			}
+		}(b, ws)
+	}
+}
+
+// ServiceStatusWsServer is a hub suitable for updating the Service Monitor.
+func ServiceStatusWsServer() *broadcastHub {
+	b := NewBroadcastHub(
+		"service status",
+		func() (time.Time, error) { return DataGetLastServiceResult(), nil },
+		func() (interface{}, error) { return DataGetServiceStatus(), nil },
+	)
+	go b.Start()
+	return b
+}
+
+// TeamScoreWsServer is a hub suitable for updating the Scoreboard charts & tables.
+func TeamScoreWsServer() *broadcastHub {
+	b := NewBroadcastHub(
+		"team scores",
+		func() (time.Time, error) { return DataGetLastResult(), nil },
+		func() (interface{}, error) { return DataGetAllScoreSplitByType(), nil },
+	)
+	go b.Start()
+	return b
 }

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -35,7 +35,7 @@ func getTeamScoreIfModified(lastMod time.Time) ([]Result, time.Time, error) {
 	return r, mod, nil
 }
 
-func getServiceIfModified(lastMod time.Time) ([]interface{}, time.Time, error) {
+func getServiceIfModified(lastMod time.Time) ([]ServiceStatus, time.Time, error) {
 	mod := DataGetLastServiceResult()
 	if !mod.After(lastMod) {
 		return nil, lastMod, nil
@@ -74,7 +74,7 @@ func writer(ws *websocket.Conn, lastMod time.Time, which string) {
 		select {
 		case <-updateTicker.C:
 			var r []Result
-			var t []interface{}
+			var t []ServiceStatus
 			var err error
 
 			if which == "score" {

--- a/static/assets/js/serviceWs.js
+++ b/static/assets/js/serviceWs.js
@@ -14,7 +14,7 @@ $(function() {
 function appendScores(res) {
     var icons = 'fa-arrow-circle-up fa-arrow-circle-down fa-exclamation-circle fa-question-circle-o text-success text-danger text-warning text-muted blink';
     res.forEach(function(r) {
-        var group = $('div').find('[data-check="' + r._id + '"]');
+        var group = $('div').find('[data-check="' + r.service + '"]');
         r.teams.forEach(function(team) {
             var stat = group.find('[data-team=' + team.number + ']');
             var newIcon = 'fa-question-circle-o text-muted';

--- a/tmpl/dashboard.tmpl
+++ b/tmpl/dashboard.tmpl
@@ -20,9 +20,9 @@
     </div>
     <div class="col-md-6">
         <div class="row">
-            {{- $total := totalChallenges }}
+            {{- $allTotals := totalChallenges }}
             {{- $aquired := teamChallenges .T.Name }}
-            {{- range $key, $value := $total }}
+            {{- range $idx, $total := $allTotals }}
             <div class="col-lg-5 col-md-6">
                 <div class="panel panel-default">
                     <div id="flag-panel" class="panel-heading">
@@ -31,8 +31,8 @@
                                 <i class="fa fa-flag fa-4x"></i>
                             </div>
                             <div class="col-xs-9 text-right">
-                                <div class="huge">{{ index $aquired $key }}/{{ $value }}</div>
-                                <div>{{ $key }}</div>
+                                <div class="huge">{{ if $aquired }}{{ (index $aquired $idx).Amount }}{{ else }}0{{ end }}/{{ $total.Amount }}</div>
+                                <div>{{ $total.Group }}</div>
                             </div>
                         </div>
                     </div>

--- a/tmpl/includes/header.tmpl
+++ b/tmpl/includes/header.tmpl
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CNYHackathon</title>
+    <link rel="icon" href="data:,"> {{/* empty favicon */}}
     <link rel="stylesheet" href="/assets/bootstrap/css/bootstrap.min.css">
     <link rel="stylesheet" href="/assets/css/font-awesome.min.css">
     <link rel="stylesheet" href="/assets/css/custom.css">

--- a/tmpl/services.tmpl
+++ b/tmpl/services.tmpl
@@ -30,7 +30,7 @@
                     <div><span>{{ . }}</span></div>
                 </div>
             </div>
-            {{- range getStatus . }}
+            {{- range getStatus $teams . }}
             <div class='square-box'>
                 <div class='square-content'>
                     {{- if eq .Details "Status: 0" }}

--- a/tmpl/services.tmpl
+++ b/tmpl/services.tmpl
@@ -10,14 +10,14 @@
                     <div></div>
                 </div>
             </div>
-            {{ $teams := allTeamScores }}
+            {{ $teams := allBlueTeams }}
             {{ $max := len $teams }}
             {{- range $teams }}
             <div class='square-box'>
                 <div class='square-content labels'>
                     <div><span>
-                        <small>TEAM</small> 
-                        <b class='teamnumber'>{{ .Teamnumber }}</b>
+                        <small>TEAM</small>
+                        <b class='teamnumber'>{{ .Number }}</b>
                     </span></div>
                 </div>
             </div>


### PR DESCRIPTION
With this PR, I made quite a few improvements aimed specifically at performance. This was in response to some of the hacky fixes we had to do to keep the system running smoothly, during the last event. Originally, I only planned to do performance of the WebSocket endpoints, but the scope crept.

The two biggest improvements I found, were the rework to the WebSocket handlers, and the updates to the score calculation query.
* WebSocket: Using a pub/sub strategy worked wonders. Testing done with [the artillery tool](https://artillery.io/) showed my poor old system (i5-2520M CPU @ 2.50GHz, 4GB Mem) revitalized, going from a steadily increasing load above 2.50, to a sustainable 0.40, over a minute long evaluation.
* Score Calculation: Before calculating the total points per team, adding a simple index on the "points" field, and then pruning all the records where the points were zero, saw speed ups from 2 seconds to under 20ms. Just a little thought, for big gains, on one of the most active DB paths in the app. Tested using [vegeta](https://github.com/tsenart/vegeta).

Pretty much every database query was looked at, and changed where I felt appropriate. Most of the time, this was either to add concrete types, which make the app easier to trace, or to improve DB index usage, which is known to drastically improves performance.

There are also a handful of small fixes, like the 404 on the favicon, and improved log statements.

### Commit shortlog
* Speed up Services display page
* queries.go: Add more type safety
* Fix displays when some teams have no score
* Fix constant 404 requests for favicon
* Improve mongo index usage substantially
* checks.go: Switch to bulk insert of results
* websocket.go: Rework all WS to a pub/sub model
* queries.go: Include point deductions in scores

Closes #24