### PR TITLE
First Pass at Grafana Support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+setup/pg/grafana.db.zip filter=lfs diff=lfs merge=lfs -text

--- a/checks.toml
+++ b/checks.toml
@@ -14,6 +14,8 @@ stdout = false
 [database]
 mongodb_uri = "mongodb://127.0.0.1"
 dbname = "scorengine"
+# Uncomment & update to enable saving scores to postgres
+#postgres_uri = "postgres://localhost/cyboard"
 
 # The double-brackets make an array of structs, zero-indexed.
 # This is just a weird config file quirk, copy it for each script added and move on.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,9 @@ func init() {
 		"Prints the parsed server / check config (for debugging purposes)")
 	flags.String("mongodb-uri", "mongodb://127.0.0.1",
 		"Address of MongoDB instance to use. Also configured with the environment var: `MONGODB_URI`")
+	flags.String("postgres-uri", "",
+		"Postgres Connection string. Leave blank to disable saving scoring results to Postgres. "+
+			"Passwords can be supplied in a local .pgpass file.")
 	flags.BoolP("stdout", "s", false, "Log to standard out")
 
 	RootCmd.AddCommand(ServerCmd, CheckCmd)
@@ -53,9 +56,11 @@ func initConfig(v *viper.Viper, configName string) {
 
 	// Bind global flags & env vars to this specific config's values
 	v.BindEnv("database.mongodb_uri", "MONGODB_URI")
+	v.BindEnv("database.postgres_uri", "CY_POSTGRES_URI")
 
 	flags := RootCmd.PersistentFlags()
 	v.BindPFlag("database.mongodb_uri", flags.Lookup("mongodb-uri"))
+	v.BindPFlag("database.postgres_uri", flags.Lookup("postgres-uri"))
 	v.BindPFlag("log.stdout", flags.Lookup("stdout"))
 }
 
@@ -86,5 +91,6 @@ func mustUnmarshal(v *viper.Viper, cfg interface{}) {
 }
 
 func RootRun(cmd *cobra.Command, args []string) {
+
 	cmd.Help()
 }

--- a/config.toml
+++ b/config.toml
@@ -21,3 +21,5 @@ stdout = false
 [database]
 mongodb_uri = "mongodb://127.0.0.1"
 dbname = "scorengine"
+# Uncomment & update to enable saving scores to postgres
+#postgres_uri = "postgres://localhost/cyboard"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ba35bf08e9a188c6f81c7e44525746601d8c8a0f0ff06415c61dac345b94f7c4
-updated: 2018-04-08T10:06:02.617050715-04:00
+updated: 2018-04-11T22:20:38.064949866-04:00
 imports:
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
@@ -29,6 +29,12 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jackc/pgx
   version: da3231b0b66e2e74cdb779f1d46c5e958ba8be27
+  subpackages:
+  - chunkreader
+  - internal/sanitize
+  - pgio
+  - pgproto3
+  - pgtype
 - name: github.com/magiconair/properties
   version: 2c9e9502788518c97fe44e8955cd069417ee89df
 - name: github.com/meatballhat/negroni-logrus
@@ -37,6 +43,8 @@ imports:
   version: 00c29f56e2386353d58c599509e8dc3801b0d716
 - name: github.com/pelletier/go-toml
   version: 66540cf1fcd2c3aee6f6787dfa32a6ae9a870f12
+- name: github.com/pkg/errors
+  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
 - name: github.com/sirupsen/logrus
   version: 778f2e774c725116edbc3d039dc0dfc1cc62aae8
 - name: github.com/spf13/afero
@@ -46,11 +54,11 @@ imports:
 - name: github.com/spf13/cast
   version: 8965335b8c7107321228e3e3702cab9832751bac
 - name: github.com/spf13/cobra
-  version: 4dab30cb33e6633c33c787106bafbfbfdde7842d
+  version: cd30c2a7e91a1d63fd9a0027accf18a681e9d50b
 - name: github.com/spf13/jwalterweatherman
   version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag
-  version: 1ce0cc6db4029d97571db82f85092fccedb572ce
+  version: 329ebf1e04800d11a25047832495199d366580f3
 - name: github.com/spf13/viper
   version: 8dc2790b029dc41e2b8ff772c63c26adbb1db70d
 - name: github.com/stretchr/testify
@@ -60,7 +68,7 @@ imports:
 - name: github.com/urfave/negroni
   version: 22c5532ea862c34fdad414e90f8cc00b4f6f4cab
 - name: golang.org/x/crypto
-  version: b2aa35443fbc700ab74c586ae79b81c171851023
+  version: d6449816ce06963d9d136eee5a56fca5b0616e7e
   subpackages:
   - bcrypt
   - blowfish
@@ -71,7 +79,7 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: 2cb43934f0eece38629746959acc633cba083fe4
+  version: 7922cc490dd5a7dbaa7fd5d6196b49db59ac042f
   subpackages:
   - transform
   - unicode/norm

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 664da2cb51a94b03ce80bab7c884e7741f8f58c165d7c689100993ea83ce0a58
-updated: 2018-04-08T09:51:19.89902065-04:00
+hash: ba35bf08e9a188c6f81c7e44525746601d8c8a0f0ff06415c61dac345b94f7c4
+updated: 2018-04-08T10:06:02.617050715-04:00
 imports:
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
@@ -27,6 +27,8 @@ imports:
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/jackc/pgx
+  version: da3231b0b66e2e74cdb779f1d46c5e958ba8be27
 - name: github.com/magiconair/properties
   version: 2c9e9502788518c97fe44e8955cd069417ee89df
 - name: github.com/meatballhat/negroni-logrus

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,20 @@
 hash: 664da2cb51a94b03ce80bab7c884e7741f8f58c165d7c689100993ea83ce0a58
-updated: 2018-01-20T11:31:56.113063914-05:00
+updated: 2018-04-08T09:51:19.89902065-04:00
 imports:
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: c0091a029979286890368b4c7b301261e448e242
+  version: 94231ffd98496cbcb1c15b7bf2a9edfd5f852cd4
 - name: github.com/gorilla/securecookie
   version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
 - name: github.com/gorilla/sessions
-  version: fe21b6a095cd8a9d41cc7f412e13d35c130383f3
+  version: a2f2a3de9a4a575047f73e3e36bc85ecc3546391
 - name: github.com/gorilla/websocket
-  version: 292fd08b2560ad524ee37396253d71570339a821
+  version: eb925808374e5ca90c83401a40d711dc08c0c0f6
 - name: github.com/hashicorp/hcl
-  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
+  version: ef8a98b0bbce4a65b5aa4c368430a80ddc533168
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -28,48 +28,48 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/magiconair/properties
-  version: 49d762b9817ba1c2e9d0c69183c2b4a8b8f1d934
+  version: 2c9e9502788518c97fe44e8955cd069417ee89df
 - name: github.com/meatballhat/negroni-logrus
   version: 31067281800f66f57548a7a32d9c6c5f963fef83
 - name: github.com/mitchellh/mapstructure
-  version: b4575eea38cca1123ec2dc90c26529b5c5acfcff
+  version: 00c29f56e2386353d58c599509e8dc3801b0d716
 - name: github.com/pelletier/go-toml
-  version: acdc4509485b587f5e675510c4f2c63e90ff68a8
+  version: 66540cf1fcd2c3aee6f6787dfa32a6ae9a870f12
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: 778f2e774c725116edbc3d039dc0dfc1cc62aae8
 - name: github.com/spf13/afero
-  version: bb8f1927f2a9d3ab41c9340aa034f6b803f4359c
+  version: 63644898a8da0bc22138abf860edaf5277b6102e
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
+  version: 8965335b8c7107321228e3e3702cab9832751bac
 - name: github.com/spf13/cobra
-  version: 0c34d16c3123764e413b9ed982ada58b1c3d53ea
+  version: 4dab30cb33e6633c33c787106bafbfbfdde7842d
 - name: github.com/spf13/jwalterweatherman
   version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag
-  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
+  version: 1ce0cc6db4029d97571db82f85092fccedb572ce
 - name: github.com/spf13/viper
-  version: aafc9e6bc7b7bb53ddaa75a5ef49a17d6e654be5
+  version: 8dc2790b029dc41e2b8ff772c63c26adbb1db70d
 - name: github.com/stretchr/testify
-  version: 87b1dfb5b2fa649f52695dd9eae19abe404a4308
+  version: c679ae2cc0cb27ec3293fea7e254e47386f05d69
   subpackages:
   - assert
 - name: github.com/urfave/negroni
-  version: ff85fb036d90eda8518001242fcded1024e05c98
+  version: 22c5532ea862c34fdad414e90f8cc00b4f6f4cab
 - name: golang.org/x/crypto
-  version: a6600008915114d9c087fad9f03d75087b1a74df
+  version: b2aa35443fbc700ab74c586ae79b81c171851023
   subpackages:
   - bcrypt
   - blowfish
   - ssh/terminal
 - name: golang.org/x/sys
-  version: 2c42eef0765b9837fbdab12011af7830f55f88f0
+  version: 3b87a42e500a6dc65dae1a55d0b641295971163e
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
-  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
+  version: 2cb43934f0eece38629746959acc633cba083fe4
   subpackages:
   - transform
   - unicode/norm
@@ -83,10 +83,10 @@ imports:
 - name: gopkg.in/natefinch/lumberjack.v2
   version: a96e63847dc3c67d17befa69c303767e2f84e54f
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/davecgh/go-spew
-  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,3 +22,5 @@ import:
   - bson
 - package: gopkg.in/natefinch/lumberjack.v2
 - package: github.com/stretchr/testify
+- package: github.com/jackc/pgx
+  version: ^3.1.0

--- a/server/apiHandlers.go
+++ b/server/apiHandlers.go
@@ -186,6 +186,9 @@ func grantBonusPoints(bonus BonusDescriptor) error {
 	CaptFlagsLogger.WithField("teams", bonus.Teams).WithField("challenge", bonus.Details).WithField("chalGroup", "BONUS").
 		WithField("points", bonus.Points).Println("Bonus awarded!")
 
+	if err := PostgresScoreBonusFlags(results); err != nil {
+		Logger.Error("Failed to save bonus points scored into Postgres: ", err)
+	}
 	return DataAddResults(results, false)
 }
 

--- a/server/checks.go
+++ b/server/checks.go
@@ -148,7 +148,10 @@ func scoreAll(results []Result) {
 	if !dryRun {
 		err := DataAddResults(results, dryRun)
 		if err != nil {
-			Logger.Error("Could not insert service result:", err)
+			Logger.Error("Could not insert service result: ", err)
+		}
+		if err = PostgresScoreServices(results); err != nil {
+			Logger.Error("Could not insert service results in postgres: ", err)
 		}
 	} else {
 		for _, result := range results {
@@ -293,6 +296,7 @@ func testData() []Team {
 func ChecksRun(checkCfg *CheckConfiguration) {
 	SetupCheckServiceLogger(&checkCfg.Log)
 	SetupMongo(&checkCfg.Database, nil)
+	SetupPostgres(checkCfg.Database.PostgresURI)
 
 	for {
 		cfgNeedsReload = false

--- a/server/postgres.go
+++ b/server/postgres.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgtype"
+)
+
+type PostgresMetricsResult struct {
+	Timestamp     time.Time   `sql:"timestamp"`
+	Teamname      string      `sql:"teamname"`
+	Teamnumber    int16       `sql:"teamnumber"`
+	Points        int32       `sql:"points"`
+	Type          string      `sql:"type"`
+	Category      string      `sql:"category"`
+	ChallengeName pgtype.Text `sql:"challenge_name"`
+	ExitStatus    pgtype.Int4 `sql:"exit_status"`
+}
+
+const (
+	pgStmtScoreCapturedFlag = "scoreCapturedFlag"
+)
+
+var (
+	pgPool *pgx.ConnPool
+
+	pgResultTable    = pgx.Identifier{"cy", "result"}
+	pgServiceColumns = []string{
+		"timestamp", "teamname", "teamnumber", "points", "type", "category", "exit_status",
+	}
+	pgCtfColumns = []string{
+		"timestamp", "teamname", "teamnumber", "points", "type", "category", "challenge_name",
+	}
+)
+
+func SetupPostgres(uri string) {
+	// If the uri is unconfigured, skip saving data to Postgres
+	if uri == "" {
+		Logger.Warn("No postgres-uri specified. Disabling postgres support " +
+			"(which means no metrics in Grafana!)")
+		pgPool = nil
+		return
+	}
+
+	// Passwords can be in the PostgresURI in the config, or in a .pgpass file
+	baseCfg, err := pgx.ParseConnectionString(uri)
+	if err != nil {
+		Logger.Errorf("SetupPostgres: uri parsing failed: uri=`%v`, error=%v", uri, err)
+		Logger.Fatal("Did you check the docs? https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING")
+	}
+
+	// pgPool is a globally available Postgres session generator
+	pgPool, err = pgx.NewConnPool(pgx.ConnPoolConfig{ConnConfig: baseCfg})
+	if err != nil {
+		// pool's closed, fool
+		Logger.Fatalf("SetupPostgres: failed to create connection pool: config=%s, error=%v", PgConfigAsString(&baseCfg), err)
+	}
+
+	Logger.Info("Connected to postgres: ", PgConfigAsString(&baseCfg))
+
+	// prepare statements
+	if _, err := pgPool.Prepare(pgStmtScoreCapturedFlag,
+		`INSERT INTO cy.result (timestamp, teamname, teamnumber, points, type, category, challenge_name)
+		values ($1,$2,$3,$4,$5,$6,$7)
+		`); err != nil {
+		Logger.Fatalf("SetupPostgres: failed to prepare statement `%v`: %v", pgStmtScoreCapturedFlag, err)
+	}
+}
+
+func PostgresScoreCapturedFlag(res *Result) error {
+	if pgPool == nil {
+		return nil
+	}
+
+	_, err := pgPool.Exec(pgStmtScoreCapturedFlag,
+		res.Timestamp, res.Teamname, int16(res.Teamnumber), int32(res.Points), res.Type, res.Group, res.Details)
+	return err
+}
+
+func PostgresScoreMany(results []Result, category string) error {
+	if pgPool == nil {
+		return nil
+	}
+
+	var columns []string
+	iresults := make([][]interface{}, len(results))
+	if category == Service {
+		columns = pgServiceColumns
+		for i, r := range results {
+			xs := strings.Split(r.Details, ": ")
+			exitStatus, err := strconv.Atoi(xs[len(xs)-1])
+			if err != nil {
+				exitStatus = 3
+			}
+			iresults[i] = []interface{}{
+				r.Timestamp, r.Teamname, int16(r.Teamnumber), int32(r.Points), r.Type, r.Group, exitStatus,
+			}
+		}
+	} else {
+		columns = pgCtfColumns
+		for i, r := range results {
+			iresults[i] = []interface{}{
+				r.Timestamp, r.Teamname, int16(r.Teamnumber), int32(r.Points), r.Type, r.Group, r.Details,
+			}
+		}
+	}
+
+	_, err := pgPool.CopyFrom(
+		pgResultTable,
+		columns,
+		pgx.CopyFromRows(iresults),
+	)
+	return err
+}
+
+func PostgresScoreServices(results []Result) error {
+	return PostgresScoreMany(results, Service)
+}
+
+func PostgresScoreBonusFlags(results []Result) error {
+	return PostgresScoreMany(results, CTF)
+}
+
+func PgConfigAsString(c *pgx.ConnConfig) string {
+	var pw string
+	if c.Password != "" {
+		pw = "*****"
+	}
+
+	port := c.Port
+	if port == 0 {
+		port = 5432
+	}
+
+	return fmt.Sprintf("pgx.ConnConfig{host=%q, port=%v, db=%q, user=%q, password=%q}",
+		c.Host, port, c.Database, c.User, pw)
+}

--- a/server/postgres.go
+++ b/server/postgres.go
@@ -10,6 +10,19 @@ import (
 	"github.com/jackc/pgx/pgtype"
 )
 
+// PostgresMetricsResult represents the `cy.result` table schema
+// in the database.
+//
+// This table contains two similar but different `types`. The ChallengeName
+// column is only used for "type = 'CTF'" rows, whereas the ExitStatus column
+// is for "type = 'Service'" rows. There are better ways to implement this
+// (such as JSONB columns or actually competent table design), but that can be
+// fixed when there's more time.
+//
+// This type is not directly used at the moment, as most methods for insertion
+// in `github.com/jackc/pgx` take explicit interface{} slices. There is no
+// retrieval of rows from Postgres in cyboard, all those queries are done in
+// Grafana, a data analysis tool. The type signature sits here for reference.
 type PostgresMetricsResult struct {
 	Timestamp     time.Time   `sql:"timestamp"`
 	Teamname      string      `sql:"teamname"`
@@ -22,21 +35,30 @@ type PostgresMetricsResult struct {
 }
 
 const (
+	// pgStmtScoreCapturedFlag is the sole prepared statement, used to insert a scored flag into PG
 	pgStmtScoreCapturedFlag = "scoreCapturedFlag"
 )
 
 var (
+	// pgPool is the global conn for doing Postgres stuff.
 	pgPool *pgx.ConnPool
 
-	pgResultTable    = pgx.Identifier{"cy", "result"}
+	// pgResultTabe is the schema and table name for every teams' scores
+	pgResultTable = pgx.Identifier{"cy", "result"}
+	// pgServiceColumns are the names of the columns with values for "type = 'Service'" rows
 	pgServiceColumns = []string{
 		"timestamp", "teamname", "teamnumber", "points", "type", "category", "exit_status",
 	}
+	// pgServiceColumns are the names of the columns with values for "type = 'CTF'" rows
 	pgCtfColumns = []string{
 		"timestamp", "teamname", "teamnumber", "points", "type", "category", "challenge_name",
 	}
 )
 
+// SetupPostgres connects to a PG instance using the given `uri` parameter.
+// If the uri is empty, Postgres support is disabled. Otherwise, the global
+// `pgPool` will be set up, which will signal the app to duplicate scores into
+// Postgres as well as Mongodb.
 func SetupPostgres(uri string) {
 	// If the uri is unconfigured, skip saving data to Postgres
 	if uri == "" {
@@ -71,6 +93,7 @@ func SetupPostgres(uri string) {
 	}
 }
 
+// PostgresScoreCapturedFlag saves a single scored flag into postgres `cy.result` table
 func PostgresScoreCapturedFlag(res *Result) error {
 	if pgPool == nil {
 		return nil
@@ -81,6 +104,8 @@ func PostgresScoreCapturedFlag(res *Result) error {
 	return err
 }
 
+// PostgresScoreMany saves a slice of results into Postgres.
+// Either for 'CTF', or 'Service' type results.
 func PostgresScoreMany(results []Result, category string) error {
 	if pgPool == nil {
 		return nil
@@ -117,14 +142,18 @@ func PostgresScoreMany(results []Result, category string) error {
 	return err
 }
 
+// PostgresScoreServices saves service checker results into postgres
 func PostgresScoreServices(results []Result) error {
 	return PostgresScoreMany(results, Service)
 }
 
+// PostgresScoreServices saves bonus points/flags from results into postgres
 func PostgresScoreBonusFlags(results []Result) error {
 	return PostgresScoreMany(results, CTF)
 }
 
+// PgConfigAsString returns a string repr of a pgx.ConnConfig.
+// The password field is bleeted out if it is not-empty.
 func PgConfigAsString(c *pgx.ConnConfig) string {
 	var pw string
 	if c.Password != "" {

--- a/server/queries.go
+++ b/server/queries.go
@@ -185,8 +185,11 @@ func DataCheckFlag(team Team, chal Challenge) (FlagState, error) {
 	}
 	CaptFlagsLogger.WithField("team", result.Teamname).WithField("challenge", result.Details).WithField("chalGroup", result.Group).
 		WithField("points", result.Points).Println("Score!!")
-	test := false
-	return ValidFlag, DataAddResult(result, test)
+
+	if err := PostgresScoreCapturedFlag(&result); err != nil {
+		Logger.Error("Failed to save captured flag scored into Postgres: ", err)
+	}
+	return ValidFlag, DataAddResult(result, false)
 }
 
 func HasFlag(teamnumber int, challengeGroup, challengeName string) bool {

--- a/server/run.go
+++ b/server/run.go
@@ -14,8 +14,9 @@ type LogSettings struct {
 }
 
 type DBSettings struct {
-	URI    string `mapstructure:"mongodb_uri"`
-	DBName string
+	URI         string `mapstructure:"mongodb_uri"`
+	DBName      string
+	PostgresURI string `mapstructure:"postgres_uri"`
 }
 
 type ServerSettings struct {
@@ -44,6 +45,8 @@ func Run(cfg *Configuration) {
 	// MongoDB setup
 	SetupMongo(&cfg.Database, cfg.Server.SpecialChallenges)
 	CreateIndexes()
+	// Postgres Setup
+	SetupPostgres(cfg.Database.PostgresURI)
 	// Web Server Setup
 	CreateStore()
 	// On first run, prompt to set up an admin user

--- a/setup/pg/cyboard_schema.sql
+++ b/setup/pg/cyboard_schema.sql
@@ -33,7 +33,7 @@ COMMENT ON EXTENSION timescaledb IS 'Enables scalable inserts and complex querie
 -- Name: cy; Type: SCHEMA; Schema: -; Owner: x
 --
 
-CREATE SCHEMA cy;
+CREATE SCHEMA IF NOT EXISTS cy;
 
 
 ALTER SCHEMA cy OWNER TO cyboard_admin;
@@ -62,8 +62,8 @@ SET default_with_oids = false;
 -- Name: result; Type: TABLE; Schema: cy; Owner: cyboard_admin
 --
 
-CREATE TABLE cy.result (
-    "timestamp" timestamp without time zone NOT NULL,
+CREATE TABLE IF NOT EXISTS cy.result (
+    "timestamp" timestamptz NOT NULL,
     teamname text NOT NULL,
     teamnumber smallint NOT NULL,
     points integer NOT NULL,
@@ -115,41 +115,34 @@ COMMENT ON COLUMN cy.result.exit_status IS '(from "details") Exit code for Servi
 -- Name: result_category_index; Type: INDEX; Schema: cy; Owner: cyboard_admin
 --
 
-CREATE INDEX result_category_index ON cy.result USING btree (category);
+CREATE INDEX IF NOT EXISTS result_category_index ON cy.result USING btree (category);
 
 
 --
 -- Name: result_teamname_index; Type: INDEX; Schema: cy; Owner: cyboard_admin
 --
 
-CREATE INDEX result_teamname_index ON cy.result USING btree (teamname);
+CREATE INDEX IF NOT EXISTS result_teamname_index ON cy.result USING btree (teamname);
 
 
 --
 -- Name: result_timestamp_idx; Type: INDEX; Schema: cy; Owner: cyboard_admin
 --
 
-CREATE INDEX result_timestamp_idx ON cy.result USING btree ("timestamp" DESC);
+CREATE INDEX IF NOT EXISTS result_timestamp_idx ON cy.result USING btree ("timestamp" DESC);
 
 
 --
 -- Name: result_type_index; Type: INDEX; Schema: cy; Owner: cyboard_admin
 --
 
-CREATE INDEX result_type_index ON cy.result USING btree (type);
-
-
---
--- Name: teams_name_uindex; Type: INDEX; Schema: cy; Owner: cyboard_admin
---
-
-CREATE UNIQUE INDEX teams_name_uindex ON cy.teams USING btree (name);
+CREATE INDEX IF NOT EXISTS result_type_index ON cy.result USING btree (type);
 
 
 --
 -- Setup Timescale Hypertable
 --
-SELECT create_hypertable('cy.result', 'timestamp')
+SELECT public.create_hypertable('cy.result', 'timestamp');
 
 
 --

--- a/setup/pg/cyboard_schema.sql
+++ b/setup/pg/cyboard_schema.sql
@@ -1,0 +1,172 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 10.3
+-- Dumped by pg_dump version 10.3
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: timescaledb; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS timescaledb WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION timescaledb; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION timescaledb IS 'Enables scalable inserts and complex queries for time-series data';
+
+
+--
+-- Name: cy; Type: SCHEMA; Schema: -; Owner: x
+--
+
+CREATE SCHEMA cy;
+
+
+ALTER SCHEMA cy OWNER TO cyboard_admin;
+
+
+--
+-- Name: tablefunc; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS tablefunc WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION tablefunc; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION tablefunc IS 'functions that manipulate whole tables, including crosstab';
+
+
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: result; Type: TABLE; Schema: cy; Owner: cyboard_admin
+--
+
+CREATE TABLE cy.result (
+    "timestamp" timestamp without time zone NOT NULL,
+    teamname text NOT NULL,
+    teamnumber smallint NOT NULL,
+    points integer NOT NULL,
+    type text NOT NULL,
+    category text NOT NULL,
+    challenge_name text,
+    exit_status integer
+);
+
+
+ALTER TABLE cy.result OWNER TO cyboard_admin;
+
+--
+-- Name: TABLE result; Type: COMMENT; Schema: cy; Owner: cyboard_admin
+--
+
+COMMENT ON TABLE cy.result IS 'Holla holla get up on dat scoreboard!!';
+
+
+--
+-- Name: COLUMN result.type; Type: COMMENT; Schema: cy; Owner: cyboard_admin
+--
+
+COMMENT ON COLUMN cy.result.type IS 'Either "CTF" or "Service"';
+
+
+--
+-- Name: COLUMN result.category; Type: COMMENT; Schema: cy; Owner: cyboard_admin
+--
+
+COMMENT ON COLUMN cy.result.category IS 'Was "group" field. Challenge group like "Wireless" or Service Check like "Router Ping"';
+
+
+--
+-- Name: COLUMN result.challenge_name; Type: COMMENT; Schema: cy; Owner: cyboard_admin
+--
+
+COMMENT ON COLUMN cy.result.challenge_name IS '(from "details") Only for "CTF"; Should be unique per team';
+
+
+--
+-- Name: COLUMN result.exit_status; Type: COMMENT; Schema: cy; Owner: cyboard_admin
+--
+
+COMMENT ON COLUMN cy.result.exit_status IS '(from "details") Exit code for Service, which looks like "Status: 0" or "Status: timed out"';
+
+
+--
+-- Name: result_category_index; Type: INDEX; Schema: cy; Owner: cyboard_admin
+--
+
+CREATE INDEX result_category_index ON cy.result USING btree (category);
+
+
+--
+-- Name: result_teamname_index; Type: INDEX; Schema: cy; Owner: cyboard_admin
+--
+
+CREATE INDEX result_teamname_index ON cy.result USING btree (teamname);
+
+
+--
+-- Name: result_timestamp_idx; Type: INDEX; Schema: cy; Owner: cyboard_admin
+--
+
+CREATE INDEX result_timestamp_idx ON cy.result USING btree ("timestamp" DESC);
+
+
+--
+-- Name: result_type_index; Type: INDEX; Schema: cy; Owner: cyboard_admin
+--
+
+CREATE INDEX result_type_index ON cy.result USING btree (type);
+
+
+--
+-- Name: teams_name_uindex; Type: INDEX; Schema: cy; Owner: cyboard_admin
+--
+
+CREATE UNIQUE INDEX teams_name_uindex ON cy.teams USING btree (name);
+
+
+--
+-- Setup Timescale Hypertable
+--
+SELECT create_hypertable('cy.result', 'timestamp')
+
+
+--
+-- Name: SCHEMA cy; Type: ACL; Schema: -; Owner: cyboard_admin
+--
+
+GRANT USAGE ON SCHEMA cy TO grafana;
+
+
+--
+-- Name: TABLE result; Type: ACL; Schema: cy; Owner: cyboard_admin
+--
+
+GRANT SELECT ON TABLE cy.result TO grafana;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/setup/pg/dupe.py
+++ b/setup/pg/dupe.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""dupe.py mirrors a cyboard mongodb results collection into a postgres table,
+for analysis in Grafana.
+
+Spring 2018, by Butters
+
+==============================================
+WARNING: THIS SCRIPT WILL DELETE ALL DATA IN THE POSTGRES `cy.result` TABLE
+
+    !!! USE WITH CAUTION !!!
+==============================================
+
+The dupe script is a fallback in case the two databases become out of sync in some
+unforseen way. Eventually, the goal is to fully migrate to a database like Postgres
+with richer query support.
+
+This script was spliced together from a few smaller scripts, which is why it's full of
+calls to other CLI tools, like `mongoexport`. This had the handy effect of not requiring
+any external python libraries, which is great because dependency management in python is
+confusing to explain to non-developers.
+"""
+
+import csv
+import datetime
+import gzip
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+print("dupe.py: Mirror scores from Cyboard's MongoDB into Postgres")
+print()
+
+if sys.version_info < (3,3):
+    sys.exit("ERROR: Python v3.3 or greater is required!")
+
+"""
+Script Configuration:
+(if you need password auth for Postgres, use a `pgpass` file!)
+"""
+
+mongo = {
+    'db': 'scorengine',
+    'collection': 'results',
+    'csv-header': "type,timestamp,group,teamname,teamnumber,details,points",
+}
+
+postgres = {
+    'user': 'cyboard_admin',
+    'db': 'cyboard',
+    'table': 'cy.result',
+    'csv-header': "timestamp,teamname,teamnumber,points,type,category,challenge_name,exit_status",
+    'setup-script': './cyboard_schema.sql',
+}
+
+
+def echo(msg):
+    print()
+    print(msg)
+    print("========================================")
+
+# Check for required commands and files
+def require_file(cfg_item, file):
+    if not os.path.exists(file):
+        # This line remains commented to remember the fallen f-string, which I will never get to use because centos is forever old as dirt
+        # sys.exit(f"File {cfg_item} not found: {file}")
+        sys.exit("File `{}` not found: {}".format(cfg_item, file))
+
+def require_cmd(cmd):
+    if not shutil.which(cmd):
+        sys.exit("Missing required command: "+cmd)
+
+require_file('PG SQL setup script', postgres['setup-script'])
+require_cmd("mongodump")
+require_cmd("psql")
+
+
+echo("CLEARING EXISTING POSTGRES")
+# Start by clearing postgres, after a prompt
+ans = input('This will drop the "{}" table. Ok? [Y/n] '.format(postgres["table"]))
+if ans.lower() == 'n':
+    sys.exit('Nothing was done. Exiting.')
+
+sql_args = "psql -d {db} -U {user}".format(db=postgres['db'], user=postgres['user']).split()
+sql_stmt_drop_old_table = b"DROP TABLE IF EXISTS %s;" % postgres['table'].encode()
+subprocess.run(sql_args, input=sql_stmt_drop_old_table)
+
+echo("INITIALIZING SCORES TABLE")
+# Then rebuild the table schema from the sql script
+with open(postgres['setup-script'], 'rt', encoding='utf-8') as sql_script:
+    subprocess.run(sql_args, stdin=sql_script)
+
+
+echo("COPYING DATA OUT OF MONGODB")
+with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8') as tmp_mongo, tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8') as tmp_pg:
+    # Copy all data out of mongodb with the export tool
+    mongo_export_args = "mongoexport -d {db} -c {coll} --type=csv --noHeaderLine --fields={header}".format(
+                         db=mongo['db'], coll=mongo['collection'], header=mongo['csv-header']).split()
+    subprocess.run(mongo_export_args, stdout=tmp_mongo)
+
+    # Flushing is required or the script won't copy every document from mongo
+    tmp_mongo.flush()
+    os.fsync(tmp_mongo)
+    tmp_mongo.seek(0)
+
+    # Reformat the dumped mongo csv for Postgres
+    reader = csv.reader(tmp_mongo)
+    writer = csv.writer(tmp_pg)
+
+    for mongo_row in reader:
+        # Juggle the structure and data types around from Mongo's into the expected Postgres columns
+        type, ts, group, teamname, teamnumber, details, points = mongo_row
+        category = group
+        # Only CTF results have challenge names
+        if type == "CTF":
+            challenge_name = details
+            exit_status = ""
+        # and only Service results have an exit status
+        else:
+            challenge_name = ""
+            st = details.split(": ")[-1]
+            exit_status = int(st) if st.isnumeric() else 3
+        pg_row = [ts, teamname, teamnumber, points, type, category, challenge_name, exit_status]
+
+        writer.writerow(pg_row)
+
+    # Flushing is required or the script won't copy every document from mongo
+    tmp_pg.flush()
+    os.fsync(tmp_pg)
+
+    echo("IMPORTING CLEANED UP DATA FROM MONGO INTO POSTGRES")
+
+    sql_stmt_copy_csv = b"\\COPY %s FROM '%s' WITH (FORMAT csv)" % (postgres['table'].encode(), tmp_pg.name.encode())
+    subprocess.run(sql_args + ["-c", sql_stmt_copy_csv])
+
+print()
+print("All set!")

--- a/setup/pg/grafana.db.zip
+++ b/setup/pg/grafana.db.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63c91db75820e11b496b8cb7eb620b277f4987061a26d22ed7aa19f87dc46e92
+size 48639


### PR DESCRIPTION
> ## Two databases?
> Yeah, I'm sorry.

# Warning: Hacks

I've written quite a lot of docs, via comments, commits, or personal messages about this, so let me make this short for once:

* Mongo's query language is lacking
* Mongo is our current db
* Grafana w/ a Postgres enables much more interesting metrics gathering
* This means __*fancy graphs*__
* So I duplicate all the scoring data from Mongo into Postgres, as it comes in
    * and there's a fallback script (`dupe.py`) that does the same process in a one-off batch job, in case the live replication gets out of sync.

Example Grafana dashboard enabled by this change:
![ctf-status-scoreboard](https://user-images.githubusercontent.com/10280999/38652508-470978b8-3dd4-11e8-83cc-c8a67799cf0c.png "fancy!")

Now ideally, we would migrate everything to use Postgres (or whichever featureful DB we decide on), but that would be a larger effort that runs the risk of many regressions, which we just don't have time to deal with right now.