### PR TITLE
Add jitter to service checks, for unpredictability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.8.x
   - 1.9.x
+  - 1.10.x
   - 1.x
 
 # A local Mongo is required for tests
@@ -13,8 +13,3 @@ install:
   - go get -v github.com/Masterminds/glide
   - cd $GOPATH/src/github.com/Masterminds/glide && git checkout v0.13.0 && go install && cd -
   - glide install
-
-# Prior to Go 1.9, wildcard matching `./...` would include the vendor/ dir:
-#     https://golang.org/doc/go1.9#vendor-dotdotdot
-# We do not want to run our dependencies' tests, so we use glide's helper:
-script: go test $(glide novendor)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ FreeBSD, CentOS, Arch, and Ubuntu. To build `cyboard`:
 1. Install Golang
     * The simplest method is to use your system's package manager
       to download the `golang` package - e.g. `yum install golang`
-    * Alternatively Download & Install [Go v1.8+][go-install]
+    * Alternatively Download & Install [Go v1.9+][go-install]
 2. _Optional_: Go demands all code be located in one central folder,
     which you may configure before proceeding: [Guide to GOPATH][gopath]
 2. Install [Glide][glide], which manages Go dependencies


### PR DESCRIPTION
To help better emulate 'actual users' who may show up at any time,
this commit adds a variable length delay between service monitoring
checks.

This commit dedicated to 'Rudi'. Thanks for making more work for me,
at the last minute.