### PR TITLE
Update authentication code, use alexedwards/scs for session management

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,15 @@
 
 
 [[projects]]
+  name = "github.com/alexedwards/scs"
+  packages = [
+    ".",
+    "stores/cookiestore"
+  ]
+  revision = "a01923edcb7f83c0c6ae7e70ad03f293e6ec9e26"
+  version = "v1.3.0"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -26,18 +35,6 @@
   version = "v1.6.2"
 
 [[projects]]
-  name = "github.com/gorilla/securecookie"
-  packages = ["."]
-  revision = "e59506cc896acb7f7bf732d4fdf5e25f7ccd8983"
-  version = "v1.1.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/gorilla/sessions"
-  packages = ["."]
-  revision = "9ee0d62e031e098d6353a069417bd6be8015af45"
-
-[[projects]]
   branch = "master"
   name = "github.com/gorilla/websocket"
   packages = ["."]
@@ -46,7 +43,18 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
@@ -99,7 +107,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "63644898a8da0bc22138abf860edaf5277b6102e"
   version = "v1.1.0"
 
@@ -148,25 +159,48 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish","ssh/terminal"]
+  packages = [
+    "bcrypt",
+    "blowfish",
+    "nacl/secretbox",
+    "poly1305",
+    "salsa20/salsa",
+    "ssh/terminal"
+  ]
   revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
-  packages = [".","bson","internal/json","internal/sasl","internal/scram"]
+  packages = [
+    ".",
+    "bson",
+    "internal/json",
+    "internal/sasl",
+    "internal/scram"
+  ]
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [[projects]]
@@ -184,6 +218,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c6d2aa5f799b8599c122543b658f3a2f5f2029c3da4d736cb6fdff3caa9953ad"
+  inputs-digest = "91acece9c97241f1394e5b910f0434391f21004d20f08cc77d9d52dd49eeb536"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,20 +30,12 @@
   version = "1.4.7"
 
 [[constraint]]
-  name = "github.com/gorilla/securecookie"
-  version = "1.1.1"
-
-[[constraint]]
-  name = "github.com/gorilla/sessions"
-  branch = "master"
+  name = "github.com/alexedwards/scs"
+  version = "1.3.0"
 
 [[constraint]]
   name = "github.com/gorilla/websocket"
   branch = "master"
-
-[[constraint]]
-  name = "github.com/jackc/pgx"
-  version = "3.1.0"
 
 [[constraint]]
   branch = "master"

--- a/server/api_handlers.go
+++ b/server/api_handlers.go
@@ -51,7 +51,7 @@ func GetPublicChallenges(w http.ResponseWriter, r *http.Request) {
 }
 
 func SubmitFlag(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team").(models.Team)
+	t := getCtxTeam(r)
 	flag, challenge := r.FormValue("flag"), r.FormValue("challenge")
 	if flag == "" && challenge == "" {
 		w.WriteHeader(http.StatusBadRequest)
@@ -261,7 +261,7 @@ func AddFlags(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if err := DataAddChallenges(&team, insertOp); err != nil {
+	if err := DataAddChallenges(team, insertOp); err != nil {
 		Logger.Error("AddFlags:", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -295,7 +295,7 @@ func AddFlag(w http.ResponseWriter, r *http.Request) {
 	} else if mux.Vars(r)["flag"] != insertOp.Name {
 		http.Error(w, "URL flag name and body's flag name must match", http.StatusBadRequest)
 		return
-	} else if !ctfIsAdminOf(&team, &insertOp) {
+	} else if !ctfIsAdminOf(team, &insertOp) {
 		Logger.WithField("challenge", insertOp.Name).WithField("team", team.Name).Error("AddFlag: unauthorized to add flag")
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return
@@ -350,7 +350,7 @@ func DeleteFlag(w http.ResponseWriter, r *http.Request) {
 // todo(tbutts): Consider a middleware or some abstraction on the Json encoding (gorilla may already provide this)
 
 func GetBreakdownOfSubmissionsPerFlag(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team").(models.Team)
+	t := getCtxTeam(r)
 	chalGroups := getChallengesOwnerOf(t.AdminOf, t.Group)
 
 	flagsWithCapCounts, err := DataGetSubmissionsPerFlag(chalGroups)
@@ -369,7 +369,7 @@ func GetBreakdownOfSubmissionsPerFlag(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetEachTeamsCapturedFlags(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team").(models.Team)
+	t := getCtxTeam(r)
 	chalGroups := getChallengesOwnerOf(t.AdminOf, t.Group)
 
 	teamsWithCapturedFlags, err := DataGetEachTeamsCapturedFlags(chalGroups)

--- a/server/authentication.go
+++ b/server/authentication.go
@@ -30,14 +30,15 @@ func init() {
 var sessionManager *scs.Manager
 
 // CreateStore initializes the global Session Manager, used to authenticate
-// users across requests.
-func CreateStore() {
+// users across requests. If secure is true, the generated browser cookies
+// will only be shared over HTTPS.
+func CreateStore(secure bool) {
 	key := getSigningKey()
 	sessionManager = scs.NewManager(cookiestore.New(key))
 	sessionManager.Name("cyboard")
-	sessionManager.Lifetime(1 * time.Hour)
+	sessionManager.Lifetime(7 * 24 * time.Hour)
 	sessionManager.Persist(true)
-	sessionManager.Secure(true)
+	sessionManager.Secure(secure)
 	sessionManager.HttpOnly(true)
 }
 

--- a/server/authentication.go
+++ b/server/authentication.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/gob"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/alexedwards/scs"
 	"github.com/alexedwards/scs/stores/cookiestore"
+	"github.com/pereztr5/cyboard/server/models"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -78,7 +78,7 @@ func CheckCreds(w http.ResponseWriter, r *http.Request) bool {
 // some internal server error, the "team" key in the context will be nil.
 func CheckSessionID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var team interface{}
+		var team *models.Team
 
 		session := sessionManager.Load(r)
 		hasID, err := session.Exists(sessionIDKey)
@@ -100,7 +100,7 @@ func CheckSessionID(next http.Handler) http.Handler {
 				}
 			}
 		}
-		ctx := context.WithValue(r.Context(), "team", team)
+		ctx := saveCtxTeam(r, team)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -19,8 +19,8 @@ func loginReq() (http.ResponseWriter, *http.Request) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/login", nil)
 	r.Form = make(url.Values)
-	r.Form.Add(FormCredsTeam, "team1")
-	r.Form.Add(FormCredsPass, "pass1")
+	r.Form.Add(formCredsTeam, "team1")
+	r.Form.Add(formCredsPass, "pass1")
 	return w, r
 }
 
@@ -39,13 +39,13 @@ func TestCheckCreds(t *testing.T) {
 		},
 		"missing password": {
 			formPrep: func(f *url.Values) {
-				f.Del(FormCredsPass)
+				f.Del(formCredsPass)
 			},
 			expect: false,
 		},
 		"missing teamname": {
 			formPrep: func(f *url.Values) {
-				f.Del(FormCredsTeam)
+				f.Del(formCredsTeam)
 			},
 			expect: false,
 		},

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -11,8 +11,8 @@ import (
 
 func init() {
 	SetupScoringLoggers(&LogSettings{Level: "warn", Stdout: true})
-	CreateStore()
 	ensureTestDB()
+	CreateStore()
 }
 
 func loginReq() (http.ResponseWriter, *http.Request) {

--- a/server/authentication_test.go
+++ b/server/authentication_test.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	SetupScoringLoggers(&LogSettings{Level: "warn", Stdout: true})
 	ensureTestDB()
-	CreateStore()
+	CreateStore(false)
 }
 
 func loginReq() (http.ResponseWriter, *http.Request) {

--- a/server/ctx.go
+++ b/server/ctx.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/pereztr5/cyboard/server/models"
@@ -13,9 +14,15 @@ const (
 	ctxOwnedChallenges
 )
 
-func getCtxTeam(r *http.Request) models.Team {
-	return r.Context().Value("team").(models.Team)
-	// return r.Context().Value(ctxTeam).(*models.Team)
+func getCtxTeam(r *http.Request) *models.Team {
+	if t := r.Context().Value(ctxTeam); t != nil {
+		return t.(*models.Team)
+	}
+	return nil
+}
+
+func saveCtxTeam(r *http.Request, team *models.Team) context.Context {
+	return context.WithValue(r.Context(), ctxTeam, team)
 }
 
 func getCtxOwnedChallenges(r *http.Request) []models.Challenge {

--- a/server/logger.go
+++ b/server/logger.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/meatballhat/negroni-logrus"
-	"github.com/pereztr5/cyboard/server/models"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -117,8 +116,8 @@ func (m *LoggerManager) newRequestMiddleware(logger *logrus.Logger) *negronilogr
 	// The removed defaults set by the library are left as comments.
 	mw.Before = func(entry *logrus.Entry, req *http.Request, remoteAddr string) *logrus.Entry {
 		team, teamName := "<none>", "<none>"
-		if req.Context().Value("team") != nil {
-			t := req.Context().Value("team").(models.Team)
+		t := getCtxTeam(req)
+		if t != nil {
 			team = t.Group
 			teamName = t.Name
 		}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -6,38 +6,7 @@ import (
 
 	"github.com/pereztr5/cyboard/server/models"
 	"github.com/urfave/negroni"
-
-	"gopkg.in/mgo.v2/bson"
 )
-
-func CheckSessionID(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var team interface{}
-
-		session := sessionManager.Load(r)
-		hasID, err := session.Exists("id")
-		if err != nil {
-			Logger.WithError(err).Error("CheckSessionID: failed to load session data")
-		} else if hasID {
-			teamID := new(bson.ObjectId)
-
-			err := session.GetObject("id", teamID)
-			if err != nil {
-				Logger.WithError(err).Error("CheckSessionID: failed to load 'id'")
-			} else {
-				t, err := GetTeamById(teamID)
-				if err != nil {
-					Logger.WithError(err).WithField("teamID", teamID).
-						Error("CheckSessionID: GetTeamById failed")
-				} else {
-					team = t
-				}
-			}
-		}
-		ctx := context.WithValue(r.Context(), "team", team)
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
 
 func RequireLogin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -17,21 +17,19 @@ func RequireLogin(next http.Handler) http.Handler {
 	})
 }
 
-type RequireGroupIsAnyOf struct {
-	whitelistedGroups []string
-}
-
-func (mw RequireGroupIsAnyOf) Middleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		team := getCtxTeam(r)
-		for _, group := range mw.whitelistedGroups {
-			if team.Group == group {
-				next.ServeHTTP(w, r)
-				return
+func RequireGroupIsAnyOf(whitelistedGroups []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			team := getCtxTeam(r)
+			for _, group := range whitelistedGroups {
+				if team.Group == group {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
-		}
-		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
-	})
+			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+		})
+	}
 }
 
 func RequireAdmin(next http.Handler) http.Handler {

--- a/server/queries.go
+++ b/server/queries.go
@@ -38,12 +38,7 @@ func GetTeamById(id *bson.ObjectId) (models.Team, error) {
 	session, teamCollection := GetSessionAndCollection("teams")
 	defer session.Close()
 
-	err := teamCollection.Find(bson.M{"_id": id}).One(&t)
-	if err != nil {
-		Logger.Printf("Error finding team by ID %v err: %v\n", id, err)
-		return t, err
-	}
-	return t, nil
+	return t, teamCollection.Find(bson.M{"_id": id}).One(&t)
 }
 
 // Get Team name and ip only used for service checking

--- a/server/queries.go
+++ b/server/queries.go
@@ -32,13 +32,13 @@ func GetTeamByTeamname(teamname string) (models.Team, error) {
 	return t, nil
 }
 
-func GetTeamById(id *bson.ObjectId) (models.Team, error) {
-	t := models.Team{}
+func GetTeamById(id *bson.ObjectId) (*models.Team, error) {
+	t := &models.Team{}
 
 	session, teamCollection := GetSessionAndCollection("teams")
 	defer session.Close()
 
-	return t, teamCollection.Find(bson.M{"_id": id}).One(&t)
+	return t, teamCollection.Find(bson.M{"_id": id}).One(t)
 }
 
 // Get Team name and ip only used for service checking
@@ -119,7 +119,7 @@ const (
 	AlreadyCaptured = 2
 )
 
-func DataCheckFlag(team models.Team, chal models.Challenge) (FlagState, error) {
+func DataCheckFlag(team *models.Team, chal models.Challenge) (FlagState, error) {
 	session, chalCollection := GetSessionAndCollection("challenges")
 	defer session.Close()
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -66,7 +66,7 @@ func CreateWebRouter(teamScoreUpdater, servicesUpdater *broadcastHub) *mux.Route
 	black := api.PathPrefix("/black/").Subrouter()
 	black.Use(
 		RequireLogin,
-		RequireGroupIsAnyOf{[]string{"admin", "blackteam"}}.Middleware,
+		RequireGroupIsAnyOf([]string{"admin", "blackteam"}),
 	)
 	black.HandleFunc("/grant_bonus", GrantBonusPoints).Methods("POST")
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -28,9 +28,9 @@ func CreateWebRouter(teamScoreUpdater, servicesUpdater *broadcastHub) *mux.Route
 	root.Use(
 		NegroniResponseWriterMiddleware,
 		UnwrapNegroniMiddleware(negroni.NewRecovery()),
-		UnwrapNegroniMiddleware(RequestLogger),
 		sessionManager.Use,
 		CheckSessionID,
+		UnwrapNegroniMiddleware(RequestLogger),
 	)
 
 	// Public Template Pages

--- a/server/routes.go
+++ b/server/routes.go
@@ -29,6 +29,7 @@ func CreateWebRouter(teamScoreUpdater, servicesUpdater *broadcastHub) *mux.Route
 		NegroniResponseWriterMiddleware,
 		UnwrapNegroniMiddleware(negroni.NewRecovery()),
 		UnwrapNegroniMiddleware(RequestLogger),
+		sessionManager.Use,
 		CheckSessionID,
 	)
 

--- a/server/run.go
+++ b/server/run.go
@@ -17,7 +17,8 @@ func Run(cfg *Configuration) {
 	SetupMongo(&cfg.Database, cfg.Server.SpecialChallenges)
 	CreateIndexes()
 	// Web Server Setup
-	CreateStore()
+	isHTTPS := cfg.Server.CertPath != "" && cfg.Server.CertKeyPath != ""
+	CreateStore(isHTTPS)
 	// On first run, prompt to set up an admin user
 	EnsureAdmin()
 
@@ -28,7 +29,7 @@ func Run(cfg *Configuration) {
 
 	sc := &cfg.Server
 
-	if sc.CertPath == "" || sc.CertKeyPath == "" {
+	if !isHTTPS {
 		Logger.Warn("SSL certs is not configured properly. Serving plain HTTP.")
 		Logger.Printf("Server running at: http://%s:%s", sc.IP, sc.HTTPPort)
 		Logger.Fatal(http.ListenAndServe(":"+sc.HTTPPort, app))

--- a/server/template_helpers.go
+++ b/server/template_helpers.go
@@ -71,7 +71,7 @@ func getAllTeamScores() []map[string]interface{} {
 	return scores
 }
 
-func allowedToConfigureChallenges(t models.Team) bool {
+func allowedToConfigureChallenges(t *models.Team) bool {
 	switch t.Group {
 	case "admin", "blackteam":
 		return true

--- a/server/template_pages.go
+++ b/server/template_pages.go
@@ -71,39 +71,20 @@ func ShowLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func SubmitLogin(w http.ResponseWriter, r *http.Request) {
-	session, err := Store.Get(r, "cyboard")
-	//if err != nil {
-	//	Logger.Warn("Getting session cookie from Store failed: ", err)
-	//}
-
-	succ := CheckCreds(w, r)
-	if succ {
-		err = session.Save(r, w)
-		if err != nil {
-			http.Error(w, http.StatusText(500), 500)
-			return
-		}
+	loggedIn := CheckCreds(w, r)
+	if loggedIn {
 		http.Redirect(w, r, "/dashboard", 302)
-		return
+	} else {
+		http.Redirect(w, r, "/login", 302)
 	}
-	http.Redirect(w, r, "/login", 302)
 }
 
 func Logout(w http.ResponseWriter, r *http.Request) {
-	session, err := Store.Get(r, "cyboard")
-	if err != nil {
-		http.Error(w, http.StatusText(400), 400)
-		return
-	}
-
-	delete(session.Values, "id")
-	// Make sure we save the session after deleting the ID.
-	err = session.Save(r, w)
+	err := sessionManager.Load(r).Destroy(w)
 	if err != nil {
 		http.Error(w, http.StatusText(500), 500)
-		return
+		Logger.WithError(err).Error("Failed to logout user")
 	}
-
 	http.Redirect(w, r, "/login", 302)
 }
 

--- a/server/template_pages.go
+++ b/server/template_pages.go
@@ -51,16 +51,16 @@ func ensureAppTemplates() {
 }
 
 func ShowHome(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team")
+	t := getCtxTeam(r)
 	p := Page{Title: "homepage"}
 	if t != nil {
-		p.T = t.(models.Team)
+		p.T = *t
 	}
 	renderTemplate(w, p)
 }
 
 func ShowLogin(w http.ResponseWriter, r *http.Request) {
-	if r.Context().Value("team") == nil {
+	if getCtxTeam(r) == nil {
 		p := Page{
 			Title: "login",
 		}
@@ -91,36 +91,36 @@ func Logout(w http.ResponseWriter, r *http.Request) {
 func ShowTeamDashboard(w http.ResponseWriter, r *http.Request) {
 	p := Page{
 		Title: "dashboard",
-		T:     r.Context().Value("team").(models.Team),
+		T:     *getCtxTeam(r),
 	}
 	renderTemplate(w, p)
 }
 
 func ShowChallenges(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team")
+	t := getCtxTeam(r)
 	if t != nil {
 		p := Page{
 			Title: "challenges",
-			T:     t.(models.Team),
+			T:     *t,
 		}
 		renderTemplate(w, p)
 	}
 }
 
 func ShowScoreboard(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team")
+	t := getCtxTeam(r)
 	p := Page{Title: "scoreboard"}
 	if t != nil {
-		p.T = t.(models.Team)
+		p.T = *t
 	}
 	renderTemplate(w, p)
 }
 
 func ShowServices(w http.ResponseWriter, r *http.Request) {
-	t := r.Context().Value("team")
+	t := getCtxTeam(r)
 	p := Page{Title: "services"}
 	if t != nil {
-		p.T = t.(models.Team)
+		p.T = *t
 	}
 	renderTemplate(w, p)
 }


### PR DESCRIPTION
I went over all the login stuff, which had accrued some gnarly logic over the years. I feel a lot more confident in it now, and believe it will be easier to maintain. 

There are still a few more security concepts to implement, most notably **csrf protection**. I was going to add that with the rest of these changes, but then in my research I realized it would be simplest to wait for support in cookies for the [SameSite attribute](https://www.owasp.org/index.php/SameSite). Support across modern browsers is ~60%, and only admin routes need the protection since normal users can't do anything destructive. So if we were appending SameSite policy, and admins are all using up to date browsers, then we would have our bases covered. Go itself should have SameSite some time this year (ref issue 15867), but it can also be trivially hacked in to something like scs (there's an open pull request for it right now). Looking forward to it.

## Commit log:

```
Auth: Switch from gorilla/sessions to alexedwards/scs
    
    Our auth needed to be gone over anyway, and while I was investigating,
    I discovered a newer library for handling session data.
    
    Advantages of scs:
    + Modern crypto that combines encryption & authentication.
        - See: https://godoc.org/golang.org/x/crypto/nacl/secretbox
        - gorilla's project lead is planning to add it as an option in
            securecookie, so its definitely good crypto.
    + Nicer API, resulting in simpler code.
        It is based around `context` from go 1.7, which gives it an
        edge in interop over gorilla's own context package.
    
    I crawled over the scs codebase, and it looks solid. I wanted to be sure
    before making the switch, though.
    
    Of course, if gorilla ever releases v2 of sessions / securecookie,
    I could see switching back. That would be purely as a gesture of
    support for elithrar, the ever hard-working golang enthusiast who
    leads development of the gorilla toolkit.

Auth: Persist session signing secret to DB
    
    Fixes a long standing bug where restarting the server would invalidate
    everyone's sessions. With the way we were using gorilla/sessions, users
    would have to manually delete their cookies just to be able to log in
    again, which was a huge headache! Not to mention the disruption of
    service. Or the hundreds of log ins I've had to do while developing.
    
    Not sure why I hadn't done this sooner.

Auth: Refactor a little and add godocs
    
    I moved the CheckSessionID middleware out of middleware.go and
    put it with the rest of the authentication stuff. Personally, it
    feels more conherent to have it all together, and I think the fact
    that it's related to logins is more relevant than the fact that it's
    a middleware function.
    
    Either way, I added godocs to make everything clear and eaiser to
    maintain.

Auth: Use pointer & uniq type for Team in session data
    
    It's better practice to pass around pointers to structs instead of
    copying them wholecloth everywhere, and using a package level type
    for context keys ensures no collisions.
    
    Also using the getCtxTeam helper everywhere saves like, 20 characters!

Fix user info in request logs
    
    The request logger gets team info from the request context, so it
    needs to come after the middleware that sets team info within the
    middleware stack.

Middleware: Refactor RequireGroupIsAnyOf
    
    Now that I looked this over again, I think I prefer writing middleware
    as closures instead of structs. I was following the suggestions of
    gorilla/mux middleware docs, but in hindsight, the resulting 'verbiage'
    when creating this mw feels better this way.

Auth: Cookies last 1 week, option to share over http
    
    The event typically lasts a weekend, so a week-long session should
    be sufficient. No need to worry about updating the expiration.
    
    The session manager can be instructed to allow cookies over http,
    which would usually be unsafe, but can be handy for testing.
    Also, I noticed that the secure flag was not being set before the
    switch to scs, even though gorilla/sessions supports it. Oops.

Update & lock new dependencies
```